### PR TITLE
change report expiry calculation

### DIFF
--- a/realtime/ash/report_text.py
+++ b/realtime/ash/report_text.py
@@ -23,7 +23,7 @@ class ReportText(QObject):
         """Token string for QPT template"""
 
         eruption_height_asl = eruption_height + vent_height
-        model_expire = time + timedelta(days=forecast_duration)
+        model_expire = time + timedelta(days=1)
 
         event = {
             # This section is from event variable


### PR DESCRIPTION
Changing the expiry calculation where before it uses the forecast duration while now the expiry is calculated 24 hours after the event time
CC @lucernae