### PR TITLE
Fix build script for production to return error codes

### DIFF
--- a/deployment/production/docker/realtime/build.sh
+++ b/deployment/production/docker/realtime/build.sh
@@ -32,6 +32,11 @@ echo "INASAFE_REALTIME_TAG=${INASAFE_REALTIME_TAG}"
 echo "Build: $REPO_NAME/$IMAGE_NAME:$TAG_NAME"
 echo "Build Args: $BUILD_ARGS"
 
-docker build -t ${REPO_NAME}/${IMAGE_NAME} ${BUILD_ARGS} .
-docker tag ${REPO_NAME}/${IMAGE_NAME} ${REPO_NAME}/${IMAGE_NAME}:${TAG_NAME}
+
+
+docker build -t ${REPO_NAME}/${IMAGE_NAME} \
+	--build-arg INASAFE_CORE_TAG=${INASAFE_CORE_TAG} \
+	--build-arg INASAFE_REALTIME_TAG=${INASAFE_REALTIME_TAG} \
+	${BUILD_ARGS} . && \
+docker tag ${REPO_NAME}/${IMAGE_NAME} ${REPO_NAME}/${IMAGE_NAME}:${TAG_NAME} && \
 docker push ${REPO_NAME}/${IMAGE_NAME}:${TAG_NAME}


### PR DESCRIPTION
Just added missing build-args and do one liner command to return error codes in sequence