### PR TITLE
Refactor Pycharm version settings

### DIFF
--- a/deployment/ansible/development/roles/pycharm/tasks/main.yml
+++ b/deployment/ansible/development/roles/pycharm/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: gather os specific variables
   include_vars:
-    file: "{{ pycharm_version }}/{{ ansible_distribution }}.yml"
+    file: "generic/{{ ansible_distribution }}.yml"
 
 - name: customize /etc/hosts
   become: yes

--- a/deployment/ansible/development/roles/pycharm/vars/2016.3/MacOSX.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2016.3/MacOSX.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/Users/{{ remote_user }}/Library/Preferences/PyCharm2016.3'

--- a/deployment/ansible/development/roles/pycharm/vars/2016.3/Ubuntu.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2016.3/Ubuntu.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/home/{{ remote_user }}/.PyCharm2016.3/config'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.1/MacOSX.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.1/MacOSX.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/Users/{{ remote_user }}/Library/Preferences/PyCharm2017.1'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.1/Ubuntu.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.1/Ubuntu.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/home/{{ remote_user }}/.PyCharm2017.1/config'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.2/MacOSX.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.2/MacOSX.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/Users/{{ remote_user }}/Library/Preferences/PyCharm2017.2'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.2/Ubuntu.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.2/Ubuntu.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/home/{{ remote_user }}/.PyCharm2017.2/config'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.3/MacOSX.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.3/MacOSX.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/Users/{{ remote_user }}/Library/Preferences/PyCharm2017.3'

--- a/deployment/ansible/development/roles/pycharm/vars/2017.3/Ubuntu.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/2017.3/Ubuntu.yml
@@ -1,3 +1,0 @@
----
-
-pycharm_settings_path: '/home/{{ remote_user }}/.PyCharm2017.3/config'

--- a/deployment/ansible/development/roles/pycharm/vars/generic/MacOSX.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/generic/MacOSX.yml
@@ -1,0 +1,3 @@
+---
+
+pycharm_settings_path: '/Users/{{ remote_user }}/Library/Preferences/PyCharm{{ pycharm_version }}'

--- a/deployment/ansible/development/roles/pycharm/vars/generic/Ubuntu.yml
+++ b/deployment/ansible/development/roles/pycharm/vars/generic/Ubuntu.yml
@@ -1,0 +1,3 @@
+---
+
+pycharm_settings_path: '/home/{{ remote_user }}/.PyCharm{{ pycharm_version }}/config'


### PR DESCRIPTION
Refactor for generic path, because it seems there will be no significant changes in the future.
Add options for PyCharm 2018.1